### PR TITLE
fix prebalancing edge case failure and remove data copy

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -19,7 +19,10 @@ class PyTradeShifts:
     Returns:
         None
     """
-    def __init__(self, crop, base_year, percentile=0.75, region="Global", testing=False):
+
+    def __init__(
+        self, crop, base_year, percentile=0.75, region="Global", testing=False
+    ):
         self.base_year = base_year
         self.crop = crop
         self.percentile = percentile
@@ -32,9 +35,7 @@ class PyTradeShifts:
             # Prebalance the trade matrix
             self.prebalance(self.production_data, self.trade_matrix)
 
-    def load_data(
-            self,
-    ):
+    def load_data(self):
         """
         Loads the data into a pandas dataframe and cleans it
         of countries with trade below a certain percentile.
@@ -47,18 +48,24 @@ class PyTradeShifts:
         """
         # Read in the data
         trade_matrix = pd.read_csv(
-            "." + os.sep +
-            "data" + os.sep +
-            "preprocessed_data" + os.sep +
-            f"{self.crop}_{self.base_year}_{self.region}_trade.csv",
+            "."
+            + os.sep
+            + "data"
+            + os.sep
+            + "preprocessed_data"
+            + os.sep
+            + f"{self.crop}_{self.base_year}_{self.region}_trade.csv",
             index_col=0,
         )
 
         production_data = pd.read_csv(
-            "." + os.sep +
-            "data" + os.sep +
-            "preprocessed_data" + os.sep +
-            f"{self.crop}_{self.base_year}_{self.region}_production.csv",
+            "."
+            + os.sep
+            + "data"
+            + os.sep
+            + "preprocessed_data"
+            + os.sep
+            + f"{self.crop}_{self.base_year}_{self.region}_production.csv",
             index_col=0,
         ).squeeze()
 
@@ -75,11 +82,8 @@ class PyTradeShifts:
         self.trade_matrix = trade_matrix
         self.production_data = production_data
 
-
     def remove_above_percentile(
-            self,
-            trade_matrix: pd.DataFrame,
-            percentile: float = 0.75
+        self, trade_matrix: pd.DataFrame, percentile: float = 0.75
     ) -> pd.DataFrame:
         """
         Removes countries with trade below a certain percentile.
@@ -95,7 +99,7 @@ class PyTradeShifts:
                 and only the relevant crop.
         """
         # Calculate the percentile out of all values in the trade matrix
-        threshold = np.percentile(trade_matrix.values, percentile*100)
+        threshold = np.percentile(trade_matrix.values, percentile * 100)
         # Set all values to 0 which are below the threshold
         trade_matrix[trade_matrix < threshold] = 0
         # Remove all countries which have no trade
@@ -106,11 +110,7 @@ class PyTradeShifts:
 
         return trade_matrix
 
-
-    def prebalance(
-            self,
-            precision=10**-3
-    ):
+    def prebalance(self, precision=10**-3):
         """
         This implementation also includes pre-balancing to ensure that countries don't
         export more than they produce and import.
@@ -121,29 +121,29 @@ class PyTradeShifts:
         Returns:
             None
         """
-        # Make a local copy of the trade matrix and production data
-        trade_matrix = self.trade_matrix.copy()
-        production_data = self.production_data.copy()
-
         # this is virtually 1:1 as in Croft et al.
-        test = production_data + trade_matrix.sum(axis=0) - trade_matrix.sum(axis=1)
+        test = (
+            self.production_data
+            + self.trade_matrix.sum(axis=0)
+            - self.trade_matrix.sum(axis=1)
+        )
         while (test <= -precision).any():
-            sf = (production_data + trade_matrix.sum(axis=0)) / trade_matrix.sum(
-                axis=1
+            sf = (
+                self.production_data + self.trade_matrix.sum(axis=0)
+            ) / self.trade_matrix.sum(axis=1)
+            multiplier = np.where(test < 0, sf, 1)
+            self.trade_matrix = pd.DataFrame(
+                np.diag(multiplier) @ self.trade_matrix.values,
+                index=self.trade_matrix.index,
+                columns=self.trade_matrix.columns,
             )
-            multiplier = ((test < 0) * sf).replace(0, 1)
-            trade_matrix = pd.DataFrame(
-                np.diag(multiplier) @ trade_matrix.values,
-                index=trade_matrix.index,
-                columns=trade_matrix.columns,
-            )
-            test = production_data + trade_matrix.sum(axis=0) - trade_matrix.sum(
-                axis=1
+            test = (
+                self.production_data
+                + self.trade_matrix.sum(axis=0)
+                - self.trade_matrix.sum(axis=1)
             )
 
-    def remove_net_zero_countries(
-            self,
-    ):
+    def remove_net_zero_countries(self):
         """
         Return production and trading data with "all zero" countries removed.
         "All zero" countries are such states that has production = 0 and sum of rows
@@ -155,23 +155,17 @@ class PyTradeShifts:
         Returns:
             None
         """
-        # Make a local copy of the trade matrix and production data
-        trade_matrix = self.trade_matrix.copy()
-        production_data = self.production_data.copy()
-
         # b_ signifies boolean here, these are filtering masks
-        b_zero_prod = production_data == 0
-        b_zero_colsum = trade_matrix.sum(axis=0) == 0
-        b_zero_rowsum = trade_matrix.sum(axis=1) == 0
+        b_zero_prod = self.production_data == 0
+        b_zero_colsum = self.trade_matrix.sum(axis=0) == 0
+        b_zero_rowsum = self.trade_matrix.sum(axis=1) == 0
         b_filter = ~(b_zero_prod & b_zero_rowsum & b_zero_colsum)
 
         # Filter out the countries with all zeroes
-        self.production_data = production_data[b_filter]
-        self.trade_matrix = trade_matrix.loc[b_filter, b_filter]
+        self.production_data = self.production_data[b_filter]
+        self.trade_matrix = self.trade_matrix.loc[b_filter, b_filter]
 
-    def correct_reexports(
-            self,
-    ):
+    def correct_reexports(self):
         """
         Removes re-exports from the trade matrix.
         This is a Python implementation of the R/Matlab code from:
@@ -193,25 +187,23 @@ class PyTradeShifts:
         Returns:
             None
         """
-        # Make a local copy of the trade matrix and production data
-        trade_matrix = self.trade_matrix.copy()
-        production_data = self.production_data.copy()
-
         # I know that the variable names here are confusing, but this is a conversion
         # by the original R code from Johanna Hedlung/Croft et al.. The variable names are the
         # same as in the R code and we leave them this way, so we can more easily
         # compare the two pieces of code if something goes wrong.
-        trade_matrix = trade_matrix.T
-        production_data = production_data.fillna(0)
+        self.trade_matrix = self.trade_matrix.T
+        self.production_data = self.production_data.fillna(0)
 
-        x = production_data + trade_matrix.sum(axis=1)
+        x = self.production_data + self.trade_matrix.sum(axis=1)
         y = np.linalg.inv(np.diag(x))
-        A = trade_matrix @ y
-        R = np.linalg.inv(np.identity(len(A)) - A) @ np.diag(production_data)
-        c = np.diag(y @ (x - trade_matrix.sum(axis=0)))
+        A = self.trade_matrix @ y
+        R = np.linalg.inv(np.identity(len(A)) - A) @ np.diag(self.production_data)
+        c = np.diag(y @ (x - self.trade_matrix.sum(axis=0)))
         R = (c @ R).T
         R[~np.isfinite(R)] = 0
         # we could consider parametrising this but Croft had this hard coded
         R[R < 0.001] = 0
 
-        self.trade_matrix = pd.DataFrame(R, index=trade_matrix.index, columns=trade_matrix.columns)
+        self.trade_matrix = pd.DataFrame(
+            R, index=self.trade_matrix.index, columns=self.trade_matrix.columns
+        )


### PR DESCRIPTION
I've removed unnecessary data copy and replaced local trade matrix/production vector variables with the class member variables; also fixed the incorrect multiplier implementation in the prebalancing function.
The multiplier in the prebalancing function was running into two edge cases: a) when sf = Inf and b) sf = 0.
New version does not have these issues and is also simpler.