### PR TITLE
main class clean up

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -331,6 +331,9 @@ def test_removing_low_trade_countries():
     # Reexport
     Wheat2018.correct_reexports()
 
+    # Set diagonal to zero
+    np.fill_diagonal(Wheat2018.trade_matrix.values, 0)
+
     # Remove countries
     Wheat2018.remove_countries()
 
@@ -418,6 +421,9 @@ def test_find_communities():
 
     # Remove countries with low trade
     Wheat2018.remove_below_percentile()
+
+    # Set diagonal to zero
+    np.fill_diagonal(Wheat2018.trade_matrix.values, 0)
 
     # Build the graph
     Wheat2018.build_graph()
@@ -542,7 +548,8 @@ def test_compare_Hedlund_results_with_model_output():
     # Remove countries
     Wheat2018.remove_countries()
 
-    Wheat2018.set_diagonal_to_zero()
+    # Set diagonal to zero
+    np.fill_diagonal(Wheat2018.trade_matrix.values, 0)
 
     cc = coco.CountryConverter()
 


### PR DESCRIPTION
I have some suggestions for a clean up here, namely:
1. Moving execution to a  run() method.
2. Removing the set_diagonal method and using the numpy one directly.
3. Removing asserts that can never run when running the class as intended, if we want them to be in testing we should add them to testing (having done the latter as I don't think that is necessary).
4. Ordering function definitions in the order that they are called.
5. Removing and keeping countries should be mutually exclusive.
6. This assert: scenario_data.max() <= 100 isn't necessary I think. The other limit makes sense (yield cannot be negative) but a +100% change would indicate doubled yield which is unlikely but not impossible.
7. Simplifying graph building -- there is an existing method of converting pandas to networkx.
8. Communities algorithm already returns a list so there is no need to cast it with list().
9. Adding return type annotations.
