### PR TITLE
Add Leiden and Infomap community detection methods

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,8 @@ dependencies:
   - geopandas=0.14.2
   - seaborn=0.13.1
   - geopy=2.4.1
+  - python-igraph=0.11.3
+  - leidenalg=0.10.2
+  - pip
+  - pip:
+    - infomap==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ networkx==3.2.1
 geopandas==0.14.2
 seaborn==0.13.1
 geopy==2.4.1
+python-igraph==0.11.3
+leidenalg==0.10.2
+infomap==2.7.1

--- a/scripts/Hedlund_base.ipynb
+++ b/scripts/Hedlund_base.ipynb
@@ -95,7 +95,7 @@
     }
    ],
    "source": [
-    "Wheat2018 = PyTradeShifts(\"Wheat\", 2018, region=\"Global\", testing=False, countries_to_remove=nan_indices)"
+    "Wheat2018 = PyTradeShifts(\"Wheat\", 2018, region=\"Global\", testing=False, countries_to_remove=nan_indices, cd_kwargs={\"seed\":2})"
    ]
   }
  ],
@@ -115,7 +115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/scripts/ISIMIP_example.ipynb
+++ b/scripts/ISIMIP_example.ipynb
@@ -94,6 +94,7 @@
     "    scenario_file_name=\"ISIMIP_climate/ISIMIP_wheat_Hedlung.csv\",\n",
     "    scenario_name=\"ISIMIP\",\n",
     "    countries_to_remove=nan_indices,\n",
+    "    cd_kwargs={\"seed\":2},\n",
     ")\n"
    ]
   }

--- a/src/model.py
+++ b/src/model.py
@@ -58,7 +58,7 @@ class PyTradeShifts:
             that are removed from the trade matrix or not.
         cd_algorithm (str, optional): Community detection algorithm name.
         Supported names: `louvain`, `leiden`, `infomap`.
-        cd_kwargs (dict, optional): Community detection algorithm kwargs.
+        cd_kwargs (dict, optional): Community detection algorithm keyworded argument.
         For possible kwargs see:
         `louvain`: https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.community.louvain.louvain_communities.html
         `leiden`: https://leidenalg.readthedocs.io/en/stable/intro.html

--- a/src/model.py
+++ b/src/model.py
@@ -14,6 +14,7 @@ from src.preprocessing import main as preprocessing_main
 from src.utils import plot_winkel_tripel_map, prepare_centroids
 import leidenalg as la
 import igraph as ig
+import infomap as imp
 
 plt.style.use(
     "https://raw.githubusercontent.com/allfed/ALLFED-matplotlib-style-sheet/main/ALLFED.mplstyle"
@@ -655,7 +656,20 @@ class PyTradeShifts:
                     for community in trade_communities
                 ]
             case "infomap":
-                raise NotImplementedError
+                # create Infomap object
+                im = imp.Infomap(**self.cd_kwargs)
+                # import netowrkx trade graph
+                im.add_networkx_graph(self.trade_graph)
+                # run the algorithm
+                im.run()
+                # extract communities
+                # using set() instead of unique() to comply with other methods'
+                trade_communities = [
+                    set(community_df["name"].values)
+                    for _, community_df in im.get_dataframe(
+                        columns=["name", "module_id"]
+                    ).groupby("module_id")
+                ]
             case _:
                 print("Unrecognised community detection method.")
                 print("Using Louvain algorithm with default parameters.")

--- a/src/model.py
+++ b/src/model.py
@@ -620,19 +620,18 @@ class PyTradeShifts:
 
         print("Built trade graph.")
 
-    def find_trade_communities(self) -> None:
+    def _get_communities(self) -> list[set[str]]:
         """
-        Finds the trade communities in the trade graph using the Louvain algorithm.
+        Private function containing the appropriate set ups and execution
+        for different community detection algorihthms.
 
         Arguments:
             None
 
         Returns:
-            None
+            list[set[str]]: list containing sets of country names.
+            Each set is a community.
         """
-        assert self.trade_graph is not None
-        assert self.trade_communities is None
-        # Find the communities
         match self.cd_algorithm:
             case "louvain":
                 trade_communities = nx.community.louvain_communities(
@@ -662,8 +661,8 @@ class PyTradeShifts:
                 im.add_networkx_graph(self.trade_graph)
                 # run the algorithm
                 im.run()
-                # extract communities
-                # using set() instead of unique() to comply with other methods'
+                # extract communities; using set() instead of unique()
+                # to comply with other methods'  data types
                 trade_communities = [
                     set(community_df["name"].values)
                     for _, community_df in im.get_dataframe(
@@ -674,6 +673,22 @@ class PyTradeShifts:
                 print("Unrecognised community detection method.")
                 print("Using Louvain algorithm with default parameters.")
                 trade_communities = nx.community.louvain_communities(self.trade_graph)
+        return trade_communities
+
+    def find_trade_communities(self) -> None:
+        """
+        Finds the trade communities in the trade graph.
+
+        Arguments:
+            None
+
+        Returns:
+            None
+        """
+        assert self.trade_graph is not None
+        assert self.trade_communities is None
+        # Find the communities
+        trade_communities = self._get_communities()
         # print number of communities found
         print(f"Found {len(trade_communities)} trade communities.")
         # Remove all the communities with only one country and print the names of the

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -446,6 +446,8 @@ def test_find_communities(cd_algorithm: str):
                 "n_iterations": 10,
                 "weights": "weight",
             }
+        case "infomap":
+            cd_kwargs = {"silent": True, "num_trials": 10}
         case _:
             cd_kwargs = {}
 


### PR DESCRIPTION
This adds Leiden (https://leidenalg.readthedocs.io/en/stable/intro.html) and Infomap (https://mapequation.github.io/infomap/python/) community detection methods to the PyTadeShifts class.
Louvain method is left in and considered the default, although the seed parameter must be passed explicitly now if desired.