### PR TITLE
Fix betweenness

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -422,6 +422,7 @@ def get_graph_efficiency(graph: nx.Graph, normalisation: str | None = "weak") ->
 
     Arguments:
         graph (nx.Graph): The graph for which to compute the efficiency metric.
+        Note: we're assuming that all edges have a `1/weight` attribute.
         normalisation (str | None, opional): Whether to normalise (and if so how)
             the efficiency score. If `None` no normalisation occurs, if `strong`
             the score is divided by the efficiency of an ideal flow graph, if
@@ -431,14 +432,7 @@ def get_graph_efficiency(graph: nx.Graph, normalisation: str | None = "weak") ->
     Returns:
         float: The efficiency score.
     """
-    all_pairs_paths = dict(
-        nx.all_pairs_dijkstra(
-            graph,
-            weight=lambda _, __, attr: (
-                attr["weight"] ** -1 if attr["weight"] != 0 else np.inf
-            ),
-        )
-    )
+    all_pairs_paths = dict(nx.all_pairs_dijkstra(graph, weight="1/weight"))
     cost_matrix = pd.DataFrame(
         0.0,
         index=graph.nodes(),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,15 @@ def test_graph_efficiency() -> None:
     """
     adj_mat = np.random.random((100, 100))
     G = nx.DiGraph(adj_mat)
+    # get efficiency requires 1/weight attribute
+    nx.set_edge_attributes(
+        G,
+        values={
+            (u, v): d["weight"] ** -1 if d["weight"] != 0 else np.inf
+            for (u, v, d) in G.edges(data=True)
+        },
+        name="1/weight",
+    )
     weak = utils.get_graph_efficiency(G, "weak")
     strong = utils.get_graph_efficiency(G, "strong")
     none = utils.get_graph_efficiency(G, None)


### PR DESCRIPTION
Currently betweenness is computed with the edge weights corresponding to trade.
IMHO, it's not quite right, because trade corresponds more to _flow_ than _cost_ , so for the computation of the shortest paths we should be using 1/weight, i.e., inverse of flow = cost.
This is already how we compute efficiency; betweenness was implemented somewhat absent-mindedly. 
This PR fixes this.